### PR TITLE
Improved ImageOptim call to fix foreground processing problems.

### DIFF
--- a/src/compress-sample-data.sh
+++ b/src/compress-sample-data.sh
@@ -44,6 +44,7 @@ echo "Using sample data $SOURCE_ARCHIVE"
 
 ORIG_SIZE=$(du -sh "$SOURCE_ARCHIVE" | awk '{ print $1 }')
 SAMPLE_DATA_DIR=$(tar -tvzf "$SOURCE_ARCHIVE" | head -1 | awk '{ print $9 }' | xargs basename)
+IMAGE_OPTIM_PATH="$(locate ImageOptim.app/Contents/MacOS/ImageOptim)"
 
 WORK_DIR="./tmp-work-dir"
 echo "Creating temporary working dir $WORK_DIR"
@@ -54,7 +55,8 @@ tar -xzf "$SOURCE_ARCHIVE"
 echo "Removing resized images cache files"
 rm -rf "$SAMPLE_DATA_DIR"/media/catalog/product/cache/*
 echo "Compressing images..."
-find "$SAMPLE_DATA_DIR" -type f \( -iname '*.jpg' -o -iname '*.png' -o -iname '*.gif' \) -exec convert -quality $TARGET_IMAGE_QUALITY_PERCENTAGE "{}" "{}" \; -exec open -a ImageOptim.app "{}" \;
+find "$SAMPLE_DATA_DIR" -type f \( -iname '*.jpg' -o -iname '*.png' -o -iname '*.gif' \) -exec convert -quality $TARGET_IMAGE_QUALITY_PERCENTAGE "{}" "{}" \;
+$IMAGE_OPTIM_PATH 2>/dev/null "$SAMPLE_DATA_DIR"
 echo "Compressing mp3 files..."
 find "$SAMPLE_DATA_DIR" -type f -iname '*.mp3' -exec lame --silent -b $TARGET_MP3_BITRATE "{}" "{}.out" \; -exec mv "{}.out" "{}" \;
 


### PR DESCRIPTION
I was noticing weird ImageOptim application behavior when I was running script in initial version. Mentioned application was getting focus on each processed file and it was hard to use OS when script was running. Also, it looks ImageOptim was doing that asynchronously and sometimes it was not being closed.

It looks similarly to issue reported in https://github.com/JamieMason/ImageOptim-CLI/issues/55 project where reporter pointed to that link:

https://imageoptim.com/command-line.html

It explains proper call to ImageOptim to use in CLI scripts. 

There is also error suppression added there as ImageOptim can throw a lot of useless messages.

@Vinai thanks for that script, it's really handy and it also works for EE demo data compressed with zip.
